### PR TITLE
Revised fs2 dependency to use direct sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,7 @@
+import github._
+
+lazy val root = project.in(file(".")).dependsOn(fs2Core, fs2IO)
+
 scalaVersion := "2.11.8"
 
 scalacOptions ++= Seq(
@@ -17,7 +21,6 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "co.fs2" %% "fs2-io" % "0.9.2",
   "io.monix" %% "monix-reactive" % "2.1.0",
   "org.scalaz.stream" %% "scalaz-stream" % "0.8.6a"
 )

--- a/project/refs.scala
+++ b/project/refs.scala
@@ -1,0 +1,18 @@
+import sbt._
+
+import scala.util.{Either, Left, Right}
+
+trait Fs2Refs {
+  def repo: Either[URI, File]
+
+  lazy val fs2Core = repo.fold(ProjectRef(_, "coreJVM"), ProjectRef(_, "coreJVM"))
+  lazy val fs2IO = repo.fold(ProjectRef(_, "io"), ProjectRef(_, "io"))
+}
+
+object github extends Fs2Refs {
+  val repo = Left(uri("git://github.com/functional-streams-for-scala/fs2.git#series/1.0"))
+}
+
+object local extends Fs2Refs {
+  val repo = Right(file("..") / "fs2")
+}


### PR DESCRIPTION
Clones from github by default.  You can change to referencing a local checkout (by default, `../fs2`) by swapping the import from `github._` to `local._`