### PR TITLE
Upgrade Monix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import github._
 
 lazy val root = project.in(file(".")).dependsOn(fs2Core, fs2IO)
 
-scalaVersion := "2.12.0"
+scalaVersion := "2.12.1"
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -21,7 +21,8 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "io.monix" %% "monix-reactive" % "2.1.1",
+  "io.monix" %% "monix-reactive" % "2.2.0-SNAPSHOT",
+  "io.monix" %% "monix-forkjoin" % "1.0",
   "org.scalaz.stream" %% "scalaz-stream" % "0.8.6a"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "io.monix" %% "monix-reactive" % "2.2.0-SNAPSHOT",
+  "io.monix" %% "monix-reactive" % "2.2.0-M1",
   "io.monix" %% "monix-forkjoin" % "1.0",
   "org.scalaz.stream" %% "scalaz-stream" % "0.8.6a"
 )

--- a/src/main/scala/Cp.scala
+++ b/src/main/scala/Cp.scala
@@ -103,7 +103,7 @@ class Cp extends BenchmarkUtils {
 
     Await.result(
       copyFile(new File("testdata/lorem-ipsum.txt"), new File("out/lorem-ipsum.txt"), 4096)
-        .runAsync(monix.execution.Scheduler.global),
+        .runAsync(monixScheduler),
       Duration.Inf
     )
   }

--- a/src/main/scala/FlatMap.scala
+++ b/src/main/scala/FlatMap.scala
@@ -69,27 +69,27 @@ class FlatMap extends BenchmarkUtils {
   @Benchmark
   def monixNow: Int = {
     import scala.concurrent._, duration._
-    import monix.eval._, monix.execution.Scheduler.Implicits.global
+    import monix.eval._
     def loop(i: Int): Task[Int] =
       if (i < size) Task.now(i + 1).flatMap(loop)
       else Task.now(i)
-    Await.result(Task.now(0).flatMap(loop).runAsync, Duration.Inf)
+    Task.now(0).flatMap(loop).runSyncMaybe.right.get
   }
 
   @Benchmark
   def monixDelay: Int = {
     import scala.concurrent._, duration._
-    import monix.eval._, monix.execution.Scheduler.Implicits.global
+    import monix.eval._    
     def loop(i: Int): Task[Int] =
-      if (i < size) Task.delay(i + 1).flatMap(loop)
-      else Task.delay(i)
-    Await.result(Task.delay(0).flatMap(loop).runAsync, Duration.Inf)
+      if (i < size) Task.eval(i + 1).flatMap(loop)
+      else Task.eval(i)
+    Task.delay(0).flatMap(loop).runSyncMaybe.right.get
   }
 
   @Benchmark
   def monixApply: Int = {
     import scala.concurrent._, duration._
-    import monix.eval._, monix.execution.Scheduler.Implicits.global
+    import monix.eval._
     def loop(i: Int): Task[Int] =
       if (i < size) Task(i + 1).flatMap(loop)
       else Task(i)

--- a/src/main/scala/Sum.scala
+++ b/src/main/scala/Sum.scala
@@ -149,7 +149,7 @@ class Sum extends BenchmarkUtils {
       Observable.fromStateAction[Long, Long](l => (l, l + 1L))(0L)
         .take(size)
         .sumL
-        .runAsync(monix.execution.Scheduler.global),
+        .runAsync(monixScheduler),
       Duration.Inf
     )
   }
@@ -158,13 +158,13 @@ class Sum extends BenchmarkUtils {
   def monixObservableFromAsyncStateActionGlobal: Long = {
     import scala.concurrent._, duration._
     import monix.eval._
-    import monix.execution.schedulers._
+    import monix.execution.ExecutionModel
     import monix.reactive.Observable
     Await.result(
       Observable.fromAsyncStateAction[Long, Long](l => Task.delay((l, l + 1L)))(0L)
         .take(size)
         .sumL
-        .runAsync(monix.execution.Scheduler.global.withExecutionModel(ExecutionModel.AlwaysAsyncExecution)),
+        .runAsync(monixScheduler.withExecutionModel(ExecutionModel.AlwaysAsyncExecution)),
       Duration.Inf
     )
   }
@@ -191,7 +191,7 @@ class Sum extends BenchmarkUtils {
     Await.result(
       Observable.fromIterable(0L until size)
         .sumL
-        .runAsync(monix.execution.Scheduler.global),
+        .runAsync(monixScheduler),
       Duration.Inf
     )
   }


### PR DESCRIPTION
We seem to have suffered some performance regressions in 2.1.x due to basically making Monix's Task safer to use, however after a round of improvements (that will be released in the next major version) I have really good results.

Here are the results of my execution using this PR:
```
[info] Benchmark                   (size)   Mode  Cnt     Score     Error  Units
[info] FlatMap.fs2Apply             10000  thrpt   20   291.459 ±   6.321  ops/s
[info] FlatMap.fs2Delay             10000  thrpt   20  2606.864 ±  26.442  ops/s
[info] FlatMap.fs2Now               10000  thrpt   20  3867.300 ± 541.241  ops/s
[info] FlatMap.futureApply          10000  thrpt   20   212.691 ±   9.508  ops/s
[info] FlatMap.futureSuccessful     10000  thrpt   20   418.736 ±  29.121  ops/s
[info] FlatMap.futureTrampolineEc   10000  thrpt   20   423.647 ±   8.543  ops/s
[info] FlatMap.monixApply           10000  thrpt   20   399.916 ±  15.858  ops/s
[info] FlatMap.monixDelay           10000  thrpt   20  4994.156 ±  40.014  ops/s
[info] FlatMap.monixNow             10000  thrpt   20  6253.182 ±  53.388  ops/s
[info] FlatMap.scalazApply          10000  thrpt   20   188.387 ±   2.989  ops/s
[info] FlatMap.scalazDelay          10000  thrpt   20  1794.680 ±  24.173  ops/s
[info] FlatMap.scalazNow            10000  thrpt   20  2041.300 ± 128.729  ops/s
```

Some details:

- Test system is a MacBook Pro with 2,2 GHz Intel Core i7 and 16 GB of RAM
- I stopped all running apps and services that I could before running these tests
- I reconfigured the used thread-pool for Monix; and the default execution model is now `SynchronousExecution`, otherwise it's not an apples to apples comparison in the `Delay` and the `Now` tests

So in terms of `flatMap` behavior, we're still the king of the hill 😜
Btw, I'm trying to make the next Typelevel Summit and Scala Days, hope to meet you there.

Happy New Year ⛄ 